### PR TITLE
Add support for tags for clients that allow them (e.g. datadog)

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -284,13 +284,13 @@ class Client
     }
 
     /**
-     * @param $tags
+     * @param array|string $tags
      * @return string
      */
     private function generateTagsMessage($tags)
     {
       // Nothing to return if no tags
-      if (empty($tags)) {
+      if (!$tags) {
         return '';
       }
 
@@ -301,13 +301,13 @@ class Client
 
       $tagsMessages = [];
       foreach ($tags as $tagKey => $tagVal) {
-        $tagVal = $this->escapeTag($tagVal);
+        $tagVal = $this->cleanTag($tagVal);
 
         if (is_numeric($tagKey)) {
           $tagsMessages[] = $tagVal;
         }
         else {
-          $tagKey = $this->escapeTag($tagKey);
+          $tagKey = $this->cleanTag($tagKey);
           $tagsMessages[] = $tagKey . ':' . $tagVal;
         }
       }
@@ -317,8 +317,11 @@ class Client
 
     /**
      * Clean up a tag value
+     *
+     * @param string $tag
+     * @return string
      */
-    private function escapeTag($tag)
+    private function cleanTag($tag)
     {
       return str_replace(array(' ', ':', '|', ',', '#'), '-', $tag);
     }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -226,4 +226,39 @@ class ClientTest extends TestCase
         $message = $this->connection->getLastMessage();
         $this->assertEquals('test.barfoo:666|s', $message);
     }
+
+    /**
+     * @dataProvider tagsProvider
+     */
+    public function testTags($tags, $expectedTagMessage)
+    {
+        $this->client->set("foobaz", 999, $tags);
+
+        $message = $this->connection->getLastMessage();
+        $this->assertEquals('test.foobaz:999|s|#' . $expectedTagMessage, $message);
+    }
+
+    /**
+     * Data provider for testTags
+     * @return array
+     */
+    public function tagsProvider()
+    {
+        return [
+          // single string tag
+          ['one', 'one'],
+
+          // basic arrays
+          [['one'], 'one'],
+          [['one', 'two'], 'one,two'],
+
+          // associative arrays
+          [['foo' => 'one', 'two'], 'foo:one,two'],
+          [['one', 'bar' => 'two'], 'one,bar:two'],
+          [['foo' => 'one', 'bar' => 'two'], 'foo:one,bar:two'],
+
+          // tag key/values with invalid characters
+          [['f,o#o' => 'o|n:e '], 'f-o-o:o-n-e-']
+        ];
+    }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -245,20 +245,26 @@ class ClientTest extends TestCase
     public function tagsProvider()
     {
         return [
-          // single string tag
-          ['one', 'one'],
+            // single string tag
+            ['one', 'one'],
 
-          // basic arrays
-          [['one'], 'one'],
-          [['one', 'two'], 'one,two'],
+            // basic arrays
+            [['one'], 'one'],
+            [['one', 'two'], 'one,two'],
 
-          // associative arrays
-          [['foo' => 'one', 'two'], 'foo:one,two'],
-          [['one', 'bar' => 'two'], 'one,bar:two'],
-          [['foo' => 'one', 'bar' => 'two'], 'foo:one,bar:two'],
+            // associative arrays
+            [['foo' => 'one', 'two'], 'foo:one,two'],
+            [['one', 'bar' => 'two'], 'one,bar:two'],
+            [['foo' => 'one', 'bar' => 'two'], 'foo:one,bar:two'],
 
-          // tag key/values with invalid characters
-          [['f,o#o' => 'o|n:e '], 'f-o-o:o-n-e-']
+            // tag key/values with invalid characters
+            [['f,o#o' => 'o|n:e '], 'f-o-o:o-n-e-'],
+
+            // Nothing stopping duplicate tags other than PHP associative arrays
+            [['one', 'one'], 'one,one'],
+            [['foo' => 'one', 'foo', 'foo'], 'foo:one,foo,foo'],
+            [['foo' => 'one', 'foo' => 'two', 'foo', 'foo'], 'foo:two,foo,foo'],
+
         ];
     }
 }


### PR DESCRIPTION
DatadogStatsd allows tags to be sent along with regular statsd metrics. Add support for tags and append them to the message.