### PR TITLE
Add a connection type that logs all messages to the PHP error log

### DIFF
--- a/lib/Connection/ErrorLog.php
+++ b/lib/Connection/ErrorLog.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Domnikl\Statsd\Connection;
+
+use Domnikl\Statsd\Connection as Connection;
+
+/**
+ * a connection class that merely logs stats to
+ * the PHP error log rather than to statsd
+ */
+class ErrorLog implements Connection
+{
+    /**
+     * Log the message
+     *
+     * @param string $message
+     */
+    public function send($message)
+    {
+        error_log($message);
+    }
+
+    /**
+     * sends multiple messages to statsd
+     *
+     * @param array $messages
+     */
+    public function sendMessages(array $messages)
+    {
+        foreach ($messages as $message) {
+            $this->send($message);
+        }
+    }
+}


### PR DESCRIPTION
This new connection logs all messages to the PHP error log for development environments that don't have access to a statsd or a graphite cluster.